### PR TITLE
Fix user timeline paging

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,8 @@ class User < ApplicationRecord
         #ツイートが空だったら抜ける（mix3@ｻﾀﾃﾞｰﾅｲﾄﾌｨｰﾊﾞｰ様、ありがとうございます）
         throw :finish if tweets.empty?
         tweets.each do |tweet|
+          next if tweet.retweeted?
+
           tweetdate = tweet.created_at.dup.localtime("+09:00").to_date
           if tweetdate == Time.zone.today
             #throw :finish if todayswords.empty? ←前日の単語カウントが0になるバグの原因

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,9 +34,10 @@ class User < ApplicationRecord
     end
 
     #さかのぼるツイートごとに単語検索する
+    query_params = { :user_id => self.twid, :exclude_replies => true, :count => 200 }
     catch :finish do
       1.upto(50) do |i|
-        tweets = client.user_timeline({user_id: self.twid, include_rts: false, exclude_replies: true, count:200, page:i})
+        tweets = client.user_timeline(query_params)
         #ツイートが空だったら抜ける（mix3@ｻﾀﾃﾞｰﾅｲﾄﾌｨｰﾊﾞｰ様、ありがとうございます）
         throw :finish if tweets.empty?
         tweets.each do |tweet|
@@ -55,6 +56,7 @@ class User < ApplicationRecord
             throw :finish
           end
         end
+        query_params[:max_id] = tweets.last.id
       end
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,18 +41,16 @@ class User < ApplicationRecord
         #ツイートが空だったら抜ける（mix3@ｻﾀﾃﾞｰﾅｲﾄﾌｨｰﾊﾞｰ様、ありがとうございます）
         throw :finish if tweets.empty?
         tweets.each do |tweet|
-          next if tweet.retweeted?
-
           tweetdate = tweet.created_at.dup.localtime("+09:00").to_date
           if tweetdate == Time.zone.today
             #throw :finish if todayswords.empty? ←前日の単語カウントが0になるバグの原因
             todayswords.each do |w|
-              w.countcache += tweet.full_text.scan(/(?=#{w.name})/).count
+              w.countcache += tweet.full_text.scan(/(?=#{w.name})/).count if !tweet.retweeted?
             end
           elsif tweetdate == Time.zone.yesterday
             throw :finish if yesterdayswords.empty?
             yesterdayswords.each do |w|
-              w.countcache += tweet.full_text.scan(/(?=#{w.name})/).count
+              w.countcache += tweet.full_text.scan(/(?=#{w.name})/).count if !tweet.retweeted?
             end
           else
             throw :finish


### PR DESCRIPTION
Twitter API の user_timeline に page 指定は無く、max_id を指定して遡るようです（未来をたどる時は since_id のようです）
ref: https://syncer.jp/Web/API/Twitter/REST_API/GET/statuses/user_timeline/

`include_rts: false` で RT を省略すると max_id が正しく取れないことに気づいたので設定を削り RT を含むようにしています

またRTを含むようになったのでスコアリングにRTを含まないように `if !tweet.retweeted` のチェックを入れました