### PR TITLE
500エラーが出た時に原因が分からないのでログに出した方が良さそう

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,11 @@ class ApplicationController < ActionController::Base
     render template: 'errors/error_404', status: 404, layout: 'application', content_type: 'text/html'
   end
 
-  def render_500
+  def render_500(e = nil)
+    if e
+      logger.error e
+      logger.error e.backtrace.join("\n")
+    end
     render template: 'errors/error_500', status: 500, layout: 'application', content_type: 'text/html'
   end
 end


### PR DESCRIPTION
ログが無いとデバッグはとても難しいので Exception 掴んだらログに吐いておくと良いと思います

おそらく `log/` 以下にログが吐かれていると思うのですが、これで 500 エラーのときに Exception の内容が出て来るようになるのではないかと思います