### PR TITLE
word は today ではなく alive

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -128,7 +128,7 @@ class User < ApplicationRecord
   def get_old_score(client)
     oldscore = 0
     self.words.each do |word|
-      oldscore += word.get_score(self, client) if !word.today?
+      oldscore += word.get_score(self, client) if !word.alive?
     end
     self.reports.each do |rp|
       oldscore += rp.succeed ? 0 : 0 if !rp.today?


### PR DESCRIPTION
https://github.com/furikake6000/RailsTest3/pull/61 の修正を適用してる状態で 500エラー が発生すると以下のようなログが出力されるようになり、word に today というメソッドが無くて Exception が飛んだということがわかるようになりますのでエラーログは出力することをお勧めします
```
Started GET "/" for 127.0.0.1 at 2017-12-20 12:57:49 +0900
Processing by StaticPagesController#home as HTML
  User Load (0.4ms)  SELECT  "users".* FROM "users" WHERE "users"."twid" = ? ORDER BY "users"."current_score_cache" DESC LIMIT ?  [["twid", "113649672"], ["LIMIT", 1]]
  Word Load (0.3ms)  SELECT "words".* FROM "words" WHERE "words"."user_id" = ?  [["user_id", 2]]
  Report Load (0.2ms)  SELECT "reports".* FROM "reports" WHERE "reports"."user_id" = ?  [["user_id", 2]]
   (0.2ms)  begin transaction
   (0.2ms)  commit transaction
undefined method `today?' for #<Word:0x007fc0df5bc0f0>
/Users/seto-wataru/.anyenv/envs/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activemodel-5.1.4/lib/active_model/attribute_methods.rb:432:in `method_missing'
/Users/seto-wataru/workspace/github/repository/RailsTest3/app/models/user.rb:131:in `block in get_old_score'
/Users/seto-wataru/.anyenv/envs/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activerecord-5.1.4/lib/active_record/relation/delegation.rb:39:in `each'
/Users/seto-wataru/.anyenv/envs/rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/activerecord-5.1.4/lib/active_record/relation/delegation.rb:39:in `each'
/Users/seto-wataru/workspace/github/repository/RailsTest3/app/models/user.rb:130:in `get_old_score'
/Users/seto-wataru/workspace/github/repository/RailsTest3/app/models/user.rb:81:in `words_reset'
/Users/seto-wataru/workspace/github/repository/RailsTest3/app/helpers/users_helper.rb:15:in `render_users_home'
/Users/seto-wataru/workspace/github/repository/RailsTest3/app/controllers/static_pages_controller.rb:4:in `home'
(snip)
```