### PR TITLE
トランザクションを使うようにする

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,10 +61,10 @@ class User < ApplicationRecord
     end
 
     yesterdayswords.each do |w|
-      w.save
+      w.save!
     end
     todayswords.each do |w|
-      w.save
+      w.save!
     end
 
     self.get_todays_score(nil)
@@ -101,7 +101,6 @@ class User < ApplicationRecord
   def get_score(client)
     #基準スコア（アップデート前のスコア）に単語スコアとレポートスコアを加算しキャッシュに保存
     self.current_score_cache = self.score + self.get_words_score(nil) + self.get_reports_score(nil)
-    self.save
     return self.current_score_cache
   end
 
@@ -114,7 +113,7 @@ class User < ApplicationRecord
     self.reports.each do |rp|
       self.todayscore += rp.succeed ? 100 : -20 if rp.today?
     end
-    self.save
+    self.save!
     return self.todayscore
   end
 
@@ -133,5 +132,17 @@ class User < ApplicationRecord
       reportscore += rp.succeed ? 100 : -20
     end
     return reportscore
+  end
+
+  def update_tw_account(user_tw_account)
+    self.name = user_tw_account.name
+    self.screen_name = user_tw_account.screen_name
+    self.url = user_tw_account.url.to_s
+    self.imgurl = ApplicationController.helpers.get_twpic_uri(user_tw_account)
+    #鍵垢判定
+    if self.is_secret != user_tw_account.protected?
+      self.is_secret = user_tw_account.protected?
+    end
+    self.save!
   end
 end

--- a/app/models/word.rb
+++ b/app/models/word.rb
@@ -42,4 +42,6 @@ class Word < ApplicationRecord
   def report_available?
     return (self.created_at.localtime("+09:00") > (Time.now - 1.hour).localtime("+09:00").beginning_of_day)
   end
+
+  attr_accessor :detectoraccount
 end

--- a/app/views/users/_detected.html.erb
+++ b/app/views/users/_detected.html.erb
@@ -1,21 +1,13 @@
-<% @words.select{|w| w.detected && !w.noticed_detection }.each do |word| %>
-
-<% word.noticed_detection = true %>
-<% word.save %>
-<% detector = User.find(word.detectorid) %>
-<% next if detector.nil? %>
-<% detectoraccount = @client.user(detector.twid.to_i) %>
-
+<% @detected_word.each do |word| %>
 <div class="alert alert-danger text-center" role="alert">
   <h4 class="alert-heading">通告</h4>
   <small>
     <p>貴方のスパイ活動が察知されました。<br/>貴方へのペナルティとして100ポイントが減算されます。</p>
     <p>摘発された暗号：「<%= word.name %>」</p>
-    <p>摘発者は<%=detectoraccount.name%>(@<%=detectoraccount.screen_name%>)であると思われます。</p>
-    <%= link_to "情報を共有する", tweetlink("私が所持していた暗号「#{word.name}」が#{detectoraccount.name}( @#{detectoraccount.screen_name} )によって暴かれてしまった..."), class: "btn btn-danger", target: "_new" %>
+    <p>摘発者は<%=word.detectoraccount.name%>(@<%=word.detectoraccount.screen_name%>)であると思われます。</p>
+    <%= link_to "情報を共有する", tweetlink("私が所持していた暗号「#{word.name}」が#{word.detectoraccount.name}( @#{word.detectoraccount.screen_name} )によって暴かれてしまった..."), class: "btn btn-danger", target: "_new" %>
     <hr>
     <p class="text-sm mb-0">未摘発の暗号が残っている場合、貴方はまだ活動を継続することが出来ます。</p>
   </small>
 </div>
-
 <% end %>

--- a/app/views/users/_user_header.html.erb
+++ b/app/views/users/_user_header.html.erb
@@ -1,9 +1,3 @@
-<% user.name = @user_tw_account.name %>
-<% user.screen_name = @user_tw_account.screen_name %>
-<% user.url = @user_tw_account.url.to_s %>
-<% user.imgurl = get_twpic_uri(@user_tw_account) %>
-<% user.save %>
-
 <div class="media mb-3">
   <%= link_to image_tag(user.imgurl, size: "96x96" , alt: user.name, class: "mr-3 rounded-circle"), user.url, target:"_new" %>
   <div class="media-body">

--- a/app/views/users/report_history.html.erb
+++ b/app/views/users/report_history.html.erb
@@ -1,5 +1,4 @@
 <h2>摘発履歴</h2>
-<% rphists = current_user.reports.all.order("created_at DESC") %>
 
 <table class="table">
   <thead>
@@ -11,16 +10,7 @@
     </tr>
   </thead>
   <tbody>
-    <% rphists.each do |rp| %>
-
-    <% if rp.reported.screen_name.nil? or rp.reported.screen_name.blank? %>
-      <% acc = @client.rp(rp.reported.twid.to_i) %>
-      <% rp.reported.name = acc.name %>
-      <% rp.reported.screen_name = acc.screen_name %>
-      <% rp.reported.url = acc.url.to_s %>
-      <% rp.reported.imgurl = get_twpic_uri(acc) %>
-      <% rp.reported.save %>
-    <% end %>
+    <% @rphists.each do |rp| %>
     <tr>
       <td><%= "#{rp.reported.name}(@#{rp.reported.screen_name})" %></td>
       <td><%= rp.word_str %></td>

--- a/app/views/words/_words.html.erb
+++ b/app/views/words/_words.html.erb
@@ -25,6 +25,6 @@
     <td><%= @user.get_score(nil) %></td>
   </tr>
 </table>
-<% if !@todayswords.empty? %>
+<% if !@todayswords.empty? && @todayswords.first.cached_at != nil %>
 <p>※ <%= smart_time_to_str(@todayswords.first.cached_at) %> 現在の情報です</p>
 <% end %>


### PR DESCRIPTION
SQLite から Postgresql に変わったことで同時書き込みエラーが減り、同時更新による二重加算やロストアップデートなどのデータ不整合が顕在化してきているのではないかという気がしていますが、いかがでしょうか

スコア計算の変更でデータ不整合の問題が無くなっているようであれば、このPRは無視してください

----

ロストアップデートというのは前の更新を後の更新で上書きしてしまうことです

参考: [https://qiita.com/tikamoto/items/f867050ff77d06a94215#ロストアップデートが起こる例](https://qiita.com/tikamoto/items/f867050ff77d06a94215#%E3%83%AD%E3%82%B9%E3%83%88%E3%82%A2%E3%83%83%E3%83%97%E3%83%87%E3%83%BC%E3%83%88%E3%81%8C%E8%B5%B7%E3%81%93%E3%82%8B%E4%BE%8B)

二重加算も二重リクエストなどで更新済みフラグを同時に読んでしまって両方の更新処理が通ってしまうなどすると発生します

こういったデータ不整合を防ぐにはロックを使う必要があります

参考: [https://qiita.com/tikamoto/items/f867050ff77d06a94215#ロストアップデートを防ぐ](https://qiita.com/tikamoto/items/f867050ff77d06a94215#%E3%83%AD%E3%82%B9%E3%83%88%E3%82%A2%E3%83%83%E3%83%97%E3%83%87%E3%83%BC%E3%83%88%E3%82%92%E9%98%B2%E3%81%90)

ということでこのPRでは transaction を使うのと select for update によるロックを入れてみました

これの対応をするにあたって以下の理由で view での更新がネックになるので controller や model にその処理を移動させたりもしています
* controller や model でトランザクションを貼ったのにその外で更新されてしまって意味がない
* view がデータを触るのは MVC 的にあまり良くない

テストがなく `トップページ` `摘発` `摘発履歴` あたりの画面を目視確認しただけなので、これを適用して問題があったとき責任が取れないので、適用する場合はよくよく開発環境での確認のうえ慎重にお願いします
データ不整合対策の参考にして頂ければ幸いです